### PR TITLE
Bump Jito-Solana Version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,7 +92,7 @@ dependencies = [
 [[package]]
 name = "anchor-attribute-access-control"
 version = "0.24.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e#ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=fdf71bcbb0d962305854884c16335e6c4271b1f2#fdf71bcbb0d962305854884c16335e6c4271b1f2"
 dependencies = [
  "anchor-syn",
  "anyhow",
@@ -105,7 +105,7 @@ dependencies = [
 [[package]]
 name = "anchor-attribute-account"
 version = "0.24.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e#ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=fdf71bcbb0d962305854884c16335e6c4271b1f2#fdf71bcbb0d962305854884c16335e6c4271b1f2"
 dependencies = [
  "anchor-syn",
  "anyhow",
@@ -119,7 +119,7 @@ dependencies = [
 [[package]]
 name = "anchor-attribute-constant"
 version = "0.24.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e#ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=fdf71bcbb0d962305854884c16335e6c4271b1f2#fdf71bcbb0d962305854884c16335e6c4271b1f2"
 dependencies = [
  "anchor-syn",
  "proc-macro2",
@@ -129,7 +129,7 @@ dependencies = [
 [[package]]
 name = "anchor-attribute-error"
 version = "0.24.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e#ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=fdf71bcbb0d962305854884c16335e6c4271b1f2#fdf71bcbb0d962305854884c16335e6c4271b1f2"
 dependencies = [
  "anchor-syn",
  "proc-macro2",
@@ -140,7 +140,7 @@ dependencies = [
 [[package]]
 name = "anchor-attribute-event"
 version = "0.24.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e#ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=fdf71bcbb0d962305854884c16335e6c4271b1f2#fdf71bcbb0d962305854884c16335e6c4271b1f2"
 dependencies = [
  "anchor-syn",
  "anyhow",
@@ -152,7 +152,7 @@ dependencies = [
 [[package]]
 name = "anchor-attribute-interface"
 version = "0.24.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e#ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=fdf71bcbb0d962305854884c16335e6c4271b1f2#fdf71bcbb0d962305854884c16335e6c4271b1f2"
 dependencies = [
  "anchor-syn",
  "anyhow",
@@ -165,7 +165,7 @@ dependencies = [
 [[package]]
 name = "anchor-attribute-program"
 version = "0.24.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e#ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=fdf71bcbb0d962305854884c16335e6c4271b1f2#fdf71bcbb0d962305854884c16335e6c4271b1f2"
 dependencies = [
  "anchor-syn",
  "anyhow",
@@ -177,7 +177,7 @@ dependencies = [
 [[package]]
 name = "anchor-attribute-state"
 version = "0.24.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e#ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=fdf71bcbb0d962305854884c16335e6c4271b1f2#fdf71bcbb0d962305854884c16335e6c4271b1f2"
 dependencies = [
  "anchor-syn",
  "anyhow",
@@ -189,7 +189,7 @@ dependencies = [
 [[package]]
 name = "anchor-derive-accounts"
 version = "0.24.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e#ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=fdf71bcbb0d962305854884c16335e6c4271b1f2#fdf71bcbb0d962305854884c16335e6c4271b1f2"
 dependencies = [
  "anchor-syn",
  "anyhow",
@@ -201,7 +201,7 @@ dependencies = [
 [[package]]
 name = "anchor-lang"
 version = "0.24.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e#ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=fdf71bcbb0d962305854884c16335e6c4271b1f2#fdf71bcbb0d962305854884c16335e6c4271b1f2"
 dependencies = [
  "anchor-attribute-access-control",
  "anchor-attribute-account",
@@ -224,7 +224,7 @@ dependencies = [
 [[package]]
 name = "anchor-syn"
 version = "0.24.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e#ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=fdf71bcbb0d962305854884c16335e6c4271b1f2#fdf71bcbb0d962305854884c16335e6c4271b1f2"
 dependencies = [
  "anyhow",
  "bs58 0.3.1",
@@ -2467,7 +2467,7 @@ dependencies = [
 [[package]]
 name = "solana-account-decoder"
 version = "1.14.10"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e#ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=fdf71bcbb0d962305854884c16335e6c4271b1f2#fdf71bcbb0d962305854884c16335e6c4271b1f2"
 dependencies = [
  "Inflector",
  "base64 0.13.1",
@@ -2491,7 +2491,7 @@ dependencies = [
 [[package]]
 name = "solana-address-lookup-table-program"
 version = "1.14.10"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e#ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=fdf71bcbb0d962305854884c16335e6c4271b1f2#fdf71bcbb0d962305854884c16335e6c4271b1f2"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -2511,7 +2511,7 @@ dependencies = [
 [[package]]
 name = "solana-config-program"
 version = "1.14.10"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e#ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=fdf71bcbb0d962305854884c16335e6c4271b1f2#fdf71bcbb0d962305854884c16335e6c4271b1f2"
 dependencies = [
  "bincode",
  "chrono",
@@ -2524,7 +2524,7 @@ dependencies = [
 [[package]]
 name = "solana-frozen-abi"
 version = "1.14.10"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e#ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=fdf71bcbb0d962305854884c16335e6c4271b1f2#fdf71bcbb0d962305854884c16335e6c4271b1f2"
 dependencies = [
  "ahash",
  "blake3",
@@ -2591,7 +2591,7 @@ dependencies = [
 [[package]]
 name = "solana-frozen-abi-macro"
 version = "1.14.10"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e#ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=fdf71bcbb0d962305854884c16335e6c4271b1f2#fdf71bcbb0d962305854884c16335e6c4271b1f2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2614,7 +2614,7 @@ dependencies = [
 [[package]]
 name = "solana-geyser-plugin-interface"
 version = "1.14.10"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e#ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=fdf71bcbb0d962305854884c16335e6c4271b1f2#fdf71bcbb0d962305854884c16335e6c4271b1f2"
 dependencies = [
  "log",
  "solana-sdk 1.14.10",
@@ -2625,7 +2625,7 @@ dependencies = [
 [[package]]
 name = "solana-logger"
 version = "1.14.10"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e#ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=fdf71bcbb0d962305854884c16335e6c4271b1f2#fdf71bcbb0d962305854884c16335e6c4271b1f2"
 dependencies = [
  "env_logger",
  "lazy_static",
@@ -2646,7 +2646,7 @@ dependencies = [
 [[package]]
 name = "solana-measure"
 version = "1.14.10"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e#ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=fdf71bcbb0d962305854884c16335e6c4271b1f2#fdf71bcbb0d962305854884c16335e6c4271b1f2"
 dependencies = [
  "log",
  "solana-sdk 1.14.10",
@@ -2655,7 +2655,7 @@ dependencies = [
 [[package]]
 name = "solana-metrics"
 version = "1.14.10"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e#ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=fdf71bcbb0d962305854884c16335e6c4271b1f2#fdf71bcbb0d962305854884c16335e6c4271b1f2"
 dependencies = [
  "crossbeam-channel",
  "gethostname",
@@ -2668,7 +2668,7 @@ dependencies = [
 [[package]]
 name = "solana-program"
 version = "1.14.10"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e#ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=fdf71bcbb0d962305854884c16335e6c4271b1f2#fdf71bcbb0d962305854884c16335e6c4271b1f2"
 dependencies = [
  "base64 0.13.1",
  "bincode",
@@ -2765,7 +2765,7 @@ dependencies = [
 [[package]]
 name = "solana-program-runtime"
 version = "1.14.10"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e#ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=fdf71bcbb0d962305854884c16335e6c4271b1f2#fdf71bcbb0d962305854884c16335e6c4271b1f2"
 dependencies = [
  "base64 0.13.1",
  "bincode",
@@ -2791,7 +2791,7 @@ dependencies = [
 [[package]]
 name = "solana-sdk"
 version = "1.14.10"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e#ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=fdf71bcbb0d962305854884c16335e6c4271b1f2#fdf71bcbb0d962305854884c16335e6c4271b1f2"
 dependencies = [
  "anchor-lang",
  "assert_matches",
@@ -2894,7 +2894,7 @@ dependencies = [
 [[package]]
 name = "solana-sdk-macro"
 version = "1.14.10"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e#ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=fdf71bcbb0d962305854884c16335e6c4271b1f2#fdf71bcbb0d962305854884c16335e6c4271b1f2"
 dependencies = [
  "bs58 0.4.0",
  "proc-macro2",
@@ -2919,7 +2919,7 @@ dependencies = [
 [[package]]
 name = "solana-transaction-status"
 version = "1.14.10"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e#ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=fdf71bcbb0d962305854884c16335e6c4271b1f2#fdf71bcbb0d962305854884c16335e6c4271b1f2"
 dependencies = [
  "Inflector",
  "base64 0.13.1",
@@ -2947,7 +2947,7 @@ dependencies = [
 [[package]]
 name = "solana-vote-program"
 version = "1.14.10"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e#ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=fdf71bcbb0d962305854884c16335e6c4271b1f2#fdf71bcbb0d962305854884c16335e6c4271b1f2"
 dependencies = [
  "bincode",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,7 +92,7 @@ dependencies = [
 [[package]]
 name = "anchor-attribute-access-control"
 version = "0.24.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=9d2671c0#9d2671c0b03c02bfb372b63c89eedb133fbbed96"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e#ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e"
 dependencies = [
  "anchor-syn",
  "anyhow",
@@ -105,7 +105,7 @@ dependencies = [
 [[package]]
 name = "anchor-attribute-account"
 version = "0.24.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=9d2671c0#9d2671c0b03c02bfb372b63c89eedb133fbbed96"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e#ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e"
 dependencies = [
  "anchor-syn",
  "anyhow",
@@ -119,7 +119,7 @@ dependencies = [
 [[package]]
 name = "anchor-attribute-constant"
 version = "0.24.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=9d2671c0#9d2671c0b03c02bfb372b63c89eedb133fbbed96"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e#ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e"
 dependencies = [
  "anchor-syn",
  "proc-macro2",
@@ -129,7 +129,7 @@ dependencies = [
 [[package]]
 name = "anchor-attribute-error"
 version = "0.24.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=9d2671c0#9d2671c0b03c02bfb372b63c89eedb133fbbed96"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e#ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e"
 dependencies = [
  "anchor-syn",
  "proc-macro2",
@@ -140,7 +140,7 @@ dependencies = [
 [[package]]
 name = "anchor-attribute-event"
 version = "0.24.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=9d2671c0#9d2671c0b03c02bfb372b63c89eedb133fbbed96"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e#ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e"
 dependencies = [
  "anchor-syn",
  "anyhow",
@@ -152,7 +152,7 @@ dependencies = [
 [[package]]
 name = "anchor-attribute-interface"
 version = "0.24.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=9d2671c0#9d2671c0b03c02bfb372b63c89eedb133fbbed96"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e#ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e"
 dependencies = [
  "anchor-syn",
  "anyhow",
@@ -165,7 +165,7 @@ dependencies = [
 [[package]]
 name = "anchor-attribute-program"
 version = "0.24.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=9d2671c0#9d2671c0b03c02bfb372b63c89eedb133fbbed96"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e#ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e"
 dependencies = [
  "anchor-syn",
  "anyhow",
@@ -177,7 +177,7 @@ dependencies = [
 [[package]]
 name = "anchor-attribute-state"
 version = "0.24.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=9d2671c0#9d2671c0b03c02bfb372b63c89eedb133fbbed96"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e#ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e"
 dependencies = [
  "anchor-syn",
  "anyhow",
@@ -189,7 +189,7 @@ dependencies = [
 [[package]]
 name = "anchor-derive-accounts"
 version = "0.24.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=9d2671c0#9d2671c0b03c02bfb372b63c89eedb133fbbed96"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e#ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e"
 dependencies = [
  "anchor-syn",
  "anyhow",
@@ -201,7 +201,7 @@ dependencies = [
 [[package]]
 name = "anchor-lang"
 version = "0.24.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=9d2671c0#9d2671c0b03c02bfb372b63c89eedb133fbbed96"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e#ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e"
 dependencies = [
  "anchor-attribute-access-control",
  "anchor-attribute-account",
@@ -224,7 +224,7 @@ dependencies = [
 [[package]]
 name = "anchor-syn"
 version = "0.24.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=9d2671c0#9d2671c0b03c02bfb372b63c89eedb133fbbed96"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e#ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e"
 dependencies = [
  "anyhow",
  "bs58 0.3.1",
@@ -250,9 +250,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.66"
+version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6"
+checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
 
 [[package]]
 name = "arrayref"
@@ -309,9 +309,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.59"
+version = "0.1.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e6e93155431f3931513b243d371981bb2770112b370c82745a1d19d2f99364"
+checksum = "677d1d8ab452a3936018a687b20e6f7cf5363d713b732b8884001317b0e48aa3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -324,7 +324,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
  "winapi",
 ]
@@ -538,9 +538,9 @@ checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
 
 [[package]]
 name = "cc"
-version = "1.0.77"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f73505338f7d905b19d18738976aae232eb46b8efc15554ffc56deb5d9ebe4"
+checksum = "a20104e2335ce8a659d6dd92a51a767a0c062599c73b343fd152cb401e828c3d"
 dependencies = [
  "jobserver",
 ]
@@ -774,9 +774,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.82"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4a41a86530d0fe7f5d9ea779916b7cadd2d4f9add748b99c2c029cbbdfaf453"
+checksum = "5add3fc1717409d029b20c5b6903fc0c0b02fa6741d820054f4a2efa5e5816fd"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -786,9 +786,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.82"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06416d667ff3e3ad2df1cd8cd8afae5da26cf9cec4d0825040f88b5ca659a2f0"
+checksum = "b4c87959ba14bc6fbc61df77c3fcfe180fc32b93538c4f1031dd802ccb5f2ff0"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -801,15 +801,15 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.82"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "820a9a2af1669deeef27cb271f476ffd196a2c4b6731336011e0ba63e2c7cf71"
+checksum = "69a3e162fde4e594ed2b07d0f83c6c67b745e7f28ce58c6df5e6b6bef99dfb59"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.82"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a08a6e2fcc370a089ad3b4aaf54db3b1b4cee38ddabce5896b33eb693275f470"
+checksum = "3e7e2adeb6a0d4a282e581096b06e1791532b7d576dcde5ccd9382acf55db8e6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1191,6 +1191,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "hmac"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1286,9 +1295,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.23.1"
+version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59df7c4e19c950e6e0e868dcc0a300b09a9b88e9ec55bd879ca819087a77355d"
+checksum = "1788965e61b367cd03a62950836d5cd41560c3577d90e40e0819373194d1661c"
 dependencies = [
  "http",
  "hyper",
@@ -1389,9 +1398,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.5.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f88c5561171189e69df9d98bcf18fd5f9558300f7ea7b801eb8a0fd748bd8745"
+checksum = "11b0d96e660696543b251e58030cf9787df56da39dab19ad60eae7353040917e"
 
 [[package]]
 name = "itertools"
@@ -1404,9 +1413,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
+checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
 
 [[package]]
 name = "jobserver"
@@ -1443,9 +1452,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.137"
+version = "0.2.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
+checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "libloading"
@@ -1507,9 +1516,9 @@ dependencies = [
 
 [[package]]
 name = "link-cplusplus"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9272ab7b96c9046fbc5bc56c06c117cb639fe2d509df0c421cad82d2915cf369"
+checksum = "ecd207c9c713c34f95a097a5b029ac2ce6010530c7b49d7fea24d977dede04f5"
 dependencies = [
  "cc",
 ]
@@ -1670,11 +1679,11 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6058e64324c71e02bc2b150e4f3bc8286db6c83092132ffa3f6b1eab0f9def5"
+checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.2.6",
  "libc",
 ]
 
@@ -1713,9 +1722,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.43"
+version = "0.10.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020433887e44c27ff16365eaa2d380547a94544ad509aff6eb5b6e3e0b27b376"
+checksum = "b102428fd03bc5edf97f62620f7298614c45cedf287c271e7ed450bbaf83f2e1"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1745,9 +1754,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.78"
+version = "0.9.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07d5c8cb6e57b3a3612064d7b18b117912b4ce70955c2504d4b741c9e244b132"
+checksum = "23bbbf7854cd45b83958ebe919f0e8e516793727652e27fda10a8384cfc790b7"
 dependencies = [
  "autocfg",
  "cc",
@@ -1891,9 +1900,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.47"
+version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
+checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
 dependencies = [
  "unicode-ident",
 ]
@@ -1975,9 +1984,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
 dependencies = [
  "proc-macro2",
 ]
@@ -2064,11 +2073,10 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e060280438193c554f654141c9ea9417886713b7acd75974c85b18a69a88e0b"
+checksum = "6db3a213adf02b3bcfd2d3846bb41cb22857d131789e01df434fb7e7bc0759b7"
 dependencies = [
- "crossbeam-deque",
  "either",
  "rayon-core",
 ]
@@ -2227,15 +2235,15 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97477e48b4cf8603ad5f7aaf897467cf42ab4218a38ef76fb14c2d6773a6d6a8"
+checksum = "5583e89e108996506031660fe09baa5011b9dd0341b89029313006d1fb508d70"
 
 [[package]]
 name = "ryu"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
+checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
 
 [[package]]
 name = "schannel"
@@ -2255,9 +2263,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "scratch"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8132065adcfd6e02db789d9285a0deb2f3fcb04002865ab67d5fb103533898"
+checksum = "ddccb15bcce173023b3fedd9436f882a0739b8dfb45e4f6b6002bee5929f61b2"
 
 [[package]]
 name = "sct"
@@ -2304,33 +2312,33 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.14"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
+checksum = "58bc9567378fc7690d6b2addae4e60ac2eeea07becb2c64b9f218b53865cba2a"
 
 [[package]]
 name = "serde"
-version = "1.0.148"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e53f64bb4ba0191d6d0676e1b141ca55047d83b74f5607e6d8eb88126c52c2dc"
+checksum = "97fed41fc1a24994d044e6db6935e69511a1153b52c15eb42493b26fa87feba0"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.7"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfc50e8183eeeb6178dcb167ae34a8051d63535023ae38b5d8d12beae193d37b"
+checksum = "718dc5fff5b36f99093fc49b280cfc96ce6fc824317783bff5a1fed0c7a64819"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.148"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a55492425aa53521babf6137309e7d34c20bbfbbfcfe2c7f3a047fd1f6b92c0c"
+checksum = "255abe9a125a985c05190d687b320c12f9b1f0b99445e608c21ba0782c719ad8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2339,9 +2347,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.89"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020ff22c755c2ed3f8cf162dbb41a7268d934702f3ed3631656ea597e08fc3db"
+checksum = "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
 dependencies = [
  "itoa",
  "ryu",
@@ -2459,7 +2467,7 @@ dependencies = [
 [[package]]
 name = "solana-account-decoder"
 version = "1.14.10"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=9d2671c0#9d2671c0b03c02bfb372b63c89eedb133fbbed96"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e#ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e"
 dependencies = [
  "Inflector",
  "base64 0.13.1",
@@ -2483,7 +2491,7 @@ dependencies = [
 [[package]]
 name = "solana-address-lookup-table-program"
 version = "1.14.10"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=9d2671c0#9d2671c0b03c02bfb372b63c89eedb133fbbed96"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e#ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -2503,7 +2511,7 @@ dependencies = [
 [[package]]
 name = "solana-config-program"
 version = "1.14.10"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=9d2671c0#9d2671c0b03c02bfb372b63c89eedb133fbbed96"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e#ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e"
 dependencies = [
  "bincode",
  "chrono",
@@ -2515,42 +2523,8 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi"
-version = "1.14.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a5fb9c1bd1cf7ccc2b96209f0a9061afb7f0e94ca1ada6caf268fd4bc5274ff"
-dependencies = [
- "ahash",
- "blake3",
- "block-buffer 0.9.0",
- "bs58 0.4.0",
- "bv",
- "byteorder",
- "cc",
- "either",
- "generic-array",
- "getrandom 0.1.16",
- "hashbrown 0.12.3",
- "im",
- "lazy_static",
- "log",
- "memmap2",
- "once_cell",
- "rand_core 0.6.4",
- "rustc_version",
- "serde",
- "serde_bytes",
- "serde_derive",
- "serde_json",
- "sha2 0.10.6",
- "solana-frozen-abi-macro 1.14.9",
- "subtle",
- "thiserror",
-]
-
-[[package]]
-name = "solana-frozen-abi"
 version = "1.14.10"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=9d2671c0#9d2671c0b03c02bfb372b63c89eedb133fbbed96"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e#ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e"
 dependencies = [
  "ahash",
  "blake3",
@@ -2581,10 +2555,43 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-frozen-abi-macro"
-version = "1.14.9"
+name = "solana-frozen-abi"
+version = "1.14.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "091d54072f4c79ecf31bb472fcd53c15329666c33b8c2a94f13475b2a263712a"
+checksum = "6c5a383f43792311db749bbed4e7794222c9f118b609bc8252b4ea3ad88b4188"
+dependencies = [
+ "ahash",
+ "blake3",
+ "block-buffer 0.9.0",
+ "bs58 0.4.0",
+ "bv",
+ "byteorder",
+ "cc",
+ "either",
+ "generic-array",
+ "getrandom 0.1.16",
+ "hashbrown 0.12.3",
+ "im",
+ "lazy_static",
+ "log",
+ "memmap2",
+ "once_cell",
+ "rand_core 0.6.4",
+ "rustc_version",
+ "serde",
+ "serde_bytes",
+ "serde_derive",
+ "serde_json",
+ "sha2 0.10.6",
+ "solana-frozen-abi-macro 1.14.11",
+ "subtle",
+ "thiserror",
+]
+
+[[package]]
+name = "solana-frozen-abi-macro"
+version = "1.14.10"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e#ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2594,8 +2601,9 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi-macro"
-version = "1.14.10"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=9d2671c0#9d2671c0b03c02bfb372b63c89eedb133fbbed96"
+version = "1.14.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "062e282539e770967500945cd2fdb78170a1ea45aff7ad1b4ce4e2cc0b557db8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2606,7 +2614,7 @@ dependencies = [
 [[package]]
 name = "solana-geyser-plugin-interface"
 version = "1.14.10"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=9d2671c0#9d2671c0b03c02bfb372b63c89eedb133fbbed96"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e#ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e"
 dependencies = [
  "log",
  "solana-sdk 1.14.10",
@@ -2616,9 +2624,8 @@ dependencies = [
 
 [[package]]
 name = "solana-logger"
-version = "1.14.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1ce09bef8af337028d7a1ebf814b7ae060530a3947ceb2d5bed177b943e38c"
+version = "1.14.10"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e#ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e"
 dependencies = [
  "env_logger",
  "lazy_static",
@@ -2627,8 +2634,9 @@ dependencies = [
 
 [[package]]
 name = "solana-logger"
-version = "1.14.10"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=9d2671c0#9d2671c0b03c02bfb372b63c89eedb133fbbed96"
+version = "1.14.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c2bcbaba2c683e7bf80ff4f3a3cdcdaabdb0b21333e8d89aed06be136193d39"
 dependencies = [
  "env_logger",
  "lazy_static",
@@ -2638,7 +2646,7 @@ dependencies = [
 [[package]]
 name = "solana-measure"
 version = "1.14.10"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=9d2671c0#9d2671c0b03c02bfb372b63c89eedb133fbbed96"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e#ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e"
 dependencies = [
  "log",
  "solana-sdk 1.14.10",
@@ -2647,7 +2655,7 @@ dependencies = [
 [[package]]
 name = "solana-metrics"
 version = "1.14.10"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=9d2671c0#9d2671c0b03c02bfb372b63c89eedb133fbbed96"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e#ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e"
 dependencies = [
  "crossbeam-channel",
  "gethostname",
@@ -2659,57 +2667,8 @@ dependencies = [
 
 [[package]]
 name = "solana-program"
-version = "1.14.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58bee7b596fdf962d5619b6331b9b6a05144d5f04a22f95cd8706d940036135a"
-dependencies = [
- "base64 0.13.1",
- "bincode",
- "bitflags",
- "blake3",
- "borsh",
- "borsh-derive",
- "bs58 0.4.0",
- "bv",
- "bytemuck",
- "cc",
- "console_error_panic_hook",
- "console_log",
- "curve25519-dalek",
- "getrandom 0.2.8",
- "itertools",
- "js-sys",
- "lazy_static",
- "libc",
- "libsecp256k1",
- "log",
- "memoffset 0.6.5",
- "num-derive",
- "num-traits",
- "parking_lot",
- "rand 0.7.3",
- "rand_chacha 0.2.2",
- "rustc_version",
- "rustversion",
- "serde",
- "serde_bytes",
- "serde_derive",
- "serde_json",
- "sha2 0.10.6",
- "sha3 0.10.6",
- "solana-frozen-abi 1.14.9",
- "solana-frozen-abi-macro 1.14.9",
- "solana-sdk-macro 1.14.9",
- "thiserror",
- "tiny-bip39",
- "wasm-bindgen",
- "zeroize",
-]
-
-[[package]]
-name = "solana-program"
 version = "1.14.10"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=9d2671c0#9d2671c0b03c02bfb372b63c89eedb133fbbed96"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e#ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e"
 dependencies = [
  "base64 0.13.1",
  "bincode",
@@ -2755,9 +2714,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-program"
+version = "1.14.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75602376f2cea17ac301292a3ded6db73e968310ac482857237d95a34473b62a"
+dependencies = [
+ "base64 0.13.1",
+ "bincode",
+ "bitflags",
+ "blake3",
+ "borsh",
+ "borsh-derive",
+ "bs58 0.4.0",
+ "bv",
+ "bytemuck",
+ "cc",
+ "console_error_panic_hook",
+ "console_log",
+ "curve25519-dalek",
+ "getrandom 0.2.8",
+ "itertools",
+ "js-sys",
+ "lazy_static",
+ "libc",
+ "libsecp256k1",
+ "log",
+ "memoffset 0.6.5",
+ "num-derive",
+ "num-traits",
+ "parking_lot",
+ "rand 0.7.3",
+ "rand_chacha 0.2.2",
+ "rustc_version",
+ "rustversion",
+ "serde",
+ "serde_bytes",
+ "serde_derive",
+ "serde_json",
+ "sha2 0.10.6",
+ "sha3 0.10.6",
+ "solana-frozen-abi 1.14.11",
+ "solana-frozen-abi-macro 1.14.11",
+ "solana-sdk-macro 1.14.11",
+ "thiserror",
+ "tiny-bip39",
+ "wasm-bindgen",
+ "zeroize",
+]
+
+[[package]]
 name = "solana-program-runtime"
 version = "1.14.10"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=9d2671c0#9d2671c0b03c02bfb372b63c89eedb133fbbed96"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e#ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e"
 dependencies = [
  "base64 0.13.1",
  "bincode",
@@ -2782,59 +2790,8 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk"
-version = "1.14.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dab8992a688a99747c31b346444518a9ca44ba23faa7079f54c89eda5a947f3"
-dependencies = [
- "assert_matches",
- "base64 0.13.1",
- "bincode",
- "bitflags",
- "borsh",
- "bs58 0.4.0",
- "bytemuck",
- "byteorder",
- "chrono",
- "derivation-path",
- "digest 0.10.6",
- "ed25519-dalek",
- "ed25519-dalek-bip32",
- "generic-array",
- "hmac 0.12.1",
- "itertools",
- "js-sys",
- "lazy_static",
- "libsecp256k1",
- "log",
- "memmap2",
- "num-derive",
- "num-traits",
- "pbkdf2 0.11.0",
- "qstring",
- "rand 0.7.3",
- "rand_chacha 0.2.2",
- "rustc_version",
- "rustversion",
- "serde",
- "serde_bytes",
- "serde_derive",
- "serde_json",
- "sha2 0.10.6",
- "sha3 0.10.6",
- "solana-frozen-abi 1.14.9",
- "solana-frozen-abi-macro 1.14.9",
- "solana-logger 1.14.9",
- "solana-program 1.14.9",
- "solana-sdk-macro 1.14.9",
- "thiserror",
- "uriparse",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "solana-sdk"
 version = "1.14.10"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=9d2671c0#9d2671c0b03c02bfb372b63c89eedb133fbbed96"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e#ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e"
 dependencies = [
  "anchor-lang",
  "assert_matches",
@@ -2884,10 +2841,60 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-sdk-macro"
-version = "1.14.9"
+name = "solana-sdk"
+version = "1.14.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb026ece5b73ec6cefcba5ef96496a28c53c99e767cc77d8abffa36127783d"
+checksum = "a46085d2548bb943e7210b28b09378e361350577b391a94457ad78af1a9f75ef"
+dependencies = [
+ "assert_matches",
+ "base64 0.13.1",
+ "bincode",
+ "bitflags",
+ "borsh",
+ "bs58 0.4.0",
+ "bytemuck",
+ "byteorder",
+ "chrono",
+ "derivation-path",
+ "digest 0.10.6",
+ "ed25519-dalek",
+ "ed25519-dalek-bip32",
+ "generic-array",
+ "hmac 0.12.1",
+ "itertools",
+ "js-sys",
+ "lazy_static",
+ "libsecp256k1",
+ "log",
+ "memmap2",
+ "num-derive",
+ "num-traits",
+ "pbkdf2 0.11.0",
+ "qstring",
+ "rand 0.7.3",
+ "rand_chacha 0.2.2",
+ "rustc_version",
+ "rustversion",
+ "serde",
+ "serde_bytes",
+ "serde_derive",
+ "serde_json",
+ "sha2 0.10.6",
+ "sha3 0.10.6",
+ "solana-frozen-abi 1.14.11",
+ "solana-frozen-abi-macro 1.14.11",
+ "solana-logger 1.14.11",
+ "solana-program 1.14.11",
+ "solana-sdk-macro 1.14.11",
+ "thiserror",
+ "uriparse",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "solana-sdk-macro"
+version = "1.14.10"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e#ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e"
 dependencies = [
  "bs58 0.4.0",
  "proc-macro2",
@@ -2898,8 +2905,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk-macro"
-version = "1.14.10"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=9d2671c0#9d2671c0b03c02bfb372b63c89eedb133fbbed96"
+version = "1.14.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faa38323e649c70b698e49f1ded17849a9b5da2e0821a38ad08327307009e274"
 dependencies = [
  "bs58 0.4.0",
  "proc-macro2",
@@ -2911,7 +2919,7 @@ dependencies = [
 [[package]]
 name = "solana-transaction-status"
 version = "1.14.10"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=9d2671c0#9d2671c0b03c02bfb372b63c89eedb133fbbed96"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e#ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e"
 dependencies = [
  "Inflector",
  "base64 0.13.1",
@@ -2939,7 +2947,7 @@ dependencies = [
 [[package]]
 name = "solana-vote-program"
 version = "1.14.10"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=9d2671c0#9d2671c0b03c02bfb372b63c89eedb133fbbed96"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e#ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e"
 dependencies = [
  "bincode",
  "log",
@@ -2958,9 +2966,9 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-sdk"
-version = "1.14.9"
+version = "1.14.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91cef8396585fd3172a926e170299eee11d8dd1a445a75fc97771e1ab387534d"
+checksum = "d81faf1b8f5c550923f01e9b2c41aec8f646cceff7fd72ca6712d10a4022f163"
 dependencies = [
  "aes-gcm-siv",
  "arrayref",
@@ -2980,8 +2988,8 @@ dependencies = [
  "serde",
  "serde_json",
  "sha3 0.9.1",
- "solana-program 1.14.9",
- "solana-sdk 1.14.9",
+ "solana-program 1.14.11",
+ "solana-sdk 1.14.11",
  "subtle",
  "thiserror",
  "zeroize",
@@ -3003,7 +3011,7 @@ dependencies = [
  "borsh",
  "num-derive",
  "num-traits",
- "solana-program 1.14.9",
+ "solana-program 1.14.11",
  "spl-token",
  "spl-token-2022",
  "thiserror",
@@ -3015,7 +3023,7 @@ version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd0dc6f70db6bacea7ff25870b016a65ba1d1b6013536f08e4fd79a8f9005325"
 dependencies = [
- "solana-program 1.14.9",
+ "solana-program 1.14.11",
 ]
 
 [[package]]
@@ -3029,7 +3037,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "num_enum",
- "solana-program 1.14.9",
+ "solana-program 1.14.11",
  "thiserror",
 ]
 
@@ -3044,7 +3052,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "num_enum",
- "solana-program 1.14.9",
+ "solana-program 1.14.11",
  "solana-zk-token-sdk",
  "spl-memo",
  "spl-token",
@@ -3059,9 +3067,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.105"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b9b43d45702de4c839cb9b51d9f529c5dd26a4aff255b42b1ebc03e88ee908"
+checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3105,18 +3113,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
+checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
+checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3170,9 +3178,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.22.0"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76ce4a75fb488c605c54bf610f221cea8b0dafb53333c1a67e8ee199dcd2ae3"
+checksum = "eab6d665857cc6ca78d6e80303a02cea7a7851e85dfbd77cbdc09bd129f1ef46"
 dependencies = [
  "autocfg",
  "bytes",
@@ -3185,7 +3193,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "winapi",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -3272,9 +3280,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
+checksum = "1333c76748e868a4d9d1017b5ab53171dfd095f70c712fdb4653a406547f598f"
 dependencies = [
  "serde",
 ]
@@ -3406,9 +3414,9 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "typenum"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "unicode-bidi"
@@ -3418,9 +3426,9 @@ checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
+checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
 
 [[package]]
 name = "unicode-normalization"
@@ -3634,9 +3642,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.22.5"
+version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368bfe657969fb01238bb756d351dcade285e0f6fcbd36dcb23359a5169975be"
+checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
 dependencies = [
  "webpki 0.22.0",
 ]

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -17,7 +17,7 @@ rand = "0.7"
 serde = "1.0.130"
 serde_derive = "1.0.130"
 serde_json = "1.0.68"
-solana-sdk = { git = "https://github.com/jito-foundation/jito-solana.git", rev = "9d2671c0" }
+solana-sdk = { git = "https://github.com/jito-foundation/jito-solana.git", rev = "ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e" }
 thiserror = "1.0.37"
 tokio = { version = "1", features = ["full"] }
 tonic = { version = "0.6", features = ["tls"] }

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -17,7 +17,7 @@ rand = "0.7"
 serde = "1.0.130"
 serde_derive = "1.0.130"
 serde_json = "1.0.68"
-solana-sdk = { git = "https://github.com/jito-foundation/jito-solana.git", rev = "ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e" }
+solana-sdk = { git = "https://github.com/jito-foundation/jito-solana.git", rev = "fdf71bcbb0d962305854884c16335e6c4271b1f2" }
 thiserror = "1.0.37"
 tokio = { version = "1", features = ["full"] }
 tonic = { version = "0.6", features = ["tls"] }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -18,11 +18,11 @@ prost = "0.9"
 serde = "1.0.130"
 serde_derive = "1.0.103"
 serde_json = "1.0.67"
-solana-geyser-plugin-interface = { git = "https://github.com/jito-foundation/jito-solana.git", rev = "ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e" }
-solana-logger = { git = "https://github.com/jito-foundation/jito-solana.git", rev = "ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e" }
-solana-metrics = { git = "https://github.com/jito-foundation/jito-solana.git", rev = "ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e" }
-solana-program = { git = "https://github.com/jito-foundation/jito-solana.git", rev = "ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e" }
-solana-sdk = { git = "https://github.com/jito-foundation/jito-solana.git", rev = "ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e" }
+solana-geyser-plugin-interface = { git = "https://github.com/jito-foundation/jito-solana.git", rev = "fdf71bcbb0d962305854884c16335e6c4271b1f2" }
+solana-logger = { git = "https://github.com/jito-foundation/jito-solana.git", rev = "fdf71bcbb0d962305854884c16335e6c4271b1f2" }
+solana-metrics = { git = "https://github.com/jito-foundation/jito-solana.git", rev = "fdf71bcbb0d962305854884c16335e6c4271b1f2" }
+solana-program = { git = "https://github.com/jito-foundation/jito-solana.git", rev = "fdf71bcbb0d962305854884c16335e6c4271b1f2" }
+solana-sdk = { git = "https://github.com/jito-foundation/jito-solana.git", rev = "fdf71bcbb0d962305854884c16335e6c4271b1f2" }
 thiserror = "1.0.37"
 tokio = { version = "1.0", features = ["rt-multi-thread", "macros", "sync", "time"] }
 tokio-stream = "0.1"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -18,11 +18,11 @@ prost = "0.9"
 serde = "1.0.130"
 serde_derive = "1.0.103"
 serde_json = "1.0.67"
-solana-geyser-plugin-interface = { git = "https://github.com/jito-foundation/jito-solana.git", rev = "9d2671c0" }
-solana-logger = { git = "https://github.com/jito-foundation/jito-solana.git", rev = "9d2671c0" }
-solana-metrics = { git = "https://github.com/jito-foundation/jito-solana.git", rev = "9d2671c0" }
-solana-program = { git = "https://github.com/jito-foundation/jito-solana.git", rev = "9d2671c0" }
-solana-sdk = { git = "https://github.com/jito-foundation/jito-solana.git", rev = "9d2671c0" }
+solana-geyser-plugin-interface = { git = "https://github.com/jito-foundation/jito-solana.git", rev = "ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e" }
+solana-logger = { git = "https://github.com/jito-foundation/jito-solana.git", rev = "ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e" }
+solana-metrics = { git = "https://github.com/jito-foundation/jito-solana.git", rev = "ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e" }
+solana-program = { git = "https://github.com/jito-foundation/jito-solana.git", rev = "ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e" }
+solana-sdk = { git = "https://github.com/jito-foundation/jito-solana.git", rev = "ed001e5e6f6deb3c60ab75e4cfa56bfddffe890e" }
 thiserror = "1.0.37"
 tokio = { version = "1.0", features = ["rt-multi-thread", "macros", "sync", "time"] }
 tokio-stream = "0.1"


### PR DESCRIPTION
This bumps jito-solana version for https://github.com/jito-foundation/jito-solana/pull/220.

Same branch as before (v1.14-geyser-grpc-plugin)